### PR TITLE
[feat] 오늘의 뉴스, 오늘의 퀴즈, OX 퀴즈, OX 퀴즈 상세페이지

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  /* config options here */
+const nextConfig = {
+  images: {
+    domains: [
+      'images.unsplash.com', // 사용하는 외부 이미지 도메인
+    ],
+  },
 };
-
 export default nextConfig;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,9 +3,6 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
-}
-
-@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -30,11 +30,11 @@ export default function LoginPage() {
           <span>구글로 로그인</span>
         </button>
         {/* 카카오 소셜로그인 */}
-        <button type="button" className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FEE500] text-[#3C1E1E] hover:bg-[#FAE100] transition mb-1">
-          <Image src="/social/kakao_login.png" alt="카카오 로고" width={24} height={24} className="group-hover:opacity-90 transition" />
+        <button type="button" className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FEE500] text-[#3C1E1E] hover:bg-[#FFEB3B] transition mb-1">
+          <Image src="/social/kakao_login.png" alt="카카오 로고" width={24} height={24} className="group-hover:opacity-70 transition" />
           <span>카카오로 로그인</span>
         </button>
-        <Link href="/register" className="mt-4 text-center text-[#2b6cb0] font-semibold hover:underline pl-2">회원가입하기</Link>
+        <Link href="/register" className="mt-4 text-center text-[#2b6cb0] font-semibold hover:underline">회원가입하기</Link>
       </form>
     </div>
   );

--- a/src/app/oxquiz/detail/page.tsx
+++ b/src/app/oxquiz/detail/page.tsx
@@ -1,0 +1,446 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+
+// 더미 데이터 (실제에선 API로 받아오세요)
+// 미풀이 상태: 제목, 진짜기사, 가짜기사만
+const dummyQuizDetail: Record<string, {
+  title: string;
+  real: string;
+  fake: string;
+}> = {
+  '1': {
+    title: '정부, 새로운 정책 발표',
+    real: '정부는 오늘 새로운 정책을 공식 발표했습니다. 이번 정책은...',
+    fake: '정부는 오늘 모든 세금을 폐지한다고 발표했습니다. 이에 따라...',
+  },
+  '2': {
+    title: '주식시장, 사상 최고치 경신',
+    real: '오늘 주식시장은 사상 최고치를 기록하며 마감했습니다. 전문가들은...',
+    fake: '오늘 주식시장은 모든 종목이 상한가를 기록했습니다. 투자자들은...',
+  },
+  '3': {
+    title: 'AI, 일자리 대체 논란',
+    real: 'AI 기술의 발전으로 일자리 대체에 대한 우려가 커지고 있습니다.',
+    fake: 'AI가 모든 직업을 대체해 내일부터 모든 사람이 실직하게 됩니다.',
+  },
+  '4': {
+    title: '국회, 예산안 통과',
+    real: '국회에서 내년도 예산안이 통과되었습니다. 주요 내용은...',
+    fake: '국회에서 모든 예산을 폐지하고 무상복지만 실시한다고 발표했습니다.',
+  },
+  '5': {
+    title: '금리 인상, 시장 영향',
+    real: '중앙은행의 금리 인상 결정으로 시장에 영향이 나타나고 있습니다.',
+    fake: '중앙은행이 모든 이자를 폐지하고 무이자 대출을 실시한다고 발표했습니다.',
+  },
+  '6': {
+    title: '기후변화, 극한 날씨 증가',
+    real: '전 세계적으로 기후변화로 인한 극한 날씨 현상이 증가하고 있습니다.',
+    fake: '내일부터 지구가 얼어붙어 모든 생명체가 멸종한다고 발표했습니다.',
+  },
+  '7': {
+    title: '외교부, 새로운 협정 체결',
+    real: '외교부는 새로운 국가와의 협정을 체결했습니다. 협정 내용은...',
+    fake: '외교부가 모든 국가와의 외교관계를 단절한다고 발표했습니다.',
+  },
+  '8': {
+    title: '부동산 시장, 가격 변동',
+    real: '부동산 시장에서 가격 변동이 나타나고 있습니다. 전문가들은...',
+    fake: '정부가 모든 부동산을 무상으로 분배한다고 발표했습니다.',
+  },
+  '9': {
+    title: '한류, 세계적 인기 확산',
+    real: '한류 문화가 전 세계적으로 인기를 얻고 있습니다. K팝과 K드라마는...',
+    fake: '한국 문화가 전 세계에서 금지되어 모든 한류 콘텐츠가 차단됩니다.',
+  },
+  '10': {
+    title: '영화제, 새로운 작품 발표',
+    real: '국제영화제에서 새로운 작품들이 발표되었습니다. 주요 작품들은...',
+    fake: '영화제에서 모든 영화를 폐지하고 연극만 상영한다고 발표했습니다.',
+  },
+  '11': {
+    title: '전시회, 현대미술 전시',
+    real: '현대미술관에서 새로운 전시회가 열렸습니다. 전시 작품들은...',
+    fake: '모든 미술관을 폐쇄하고 그림 그리기를 금지한다고 발표했습니다.',
+  },
+  '12': {
+    title: '새로운 AI 기술 개발',
+    real: '연구진이 새로운 AI 기술을 개발했습니다. 이 기술은...',
+    fake: 'AI가 모든 기술을 대체해 인간이 더 이상 발명할 수 없다고 발표했습니다.',
+  },
+  '13': {
+    title: '메타버스, 가상현실 발전',
+    real: '메타버스 기술이 발전하여 가상현실 경험이 향상되고 있습니다.',
+    fake: '메타버스가 현실을 완전히 대체해 모든 사람이 가상세계에 살게 됩니다.',
+  },
+  '14': {
+    title: '블록체인, 기술 혁신',
+    real: '블록체인 기술의 혁신으로 다양한 분야에 적용되고 있습니다.',
+    fake: '블록체인이 모든 은행을 대체해 현금이 완전히 사라집니다.',
+  },
+  '15': {
+    title: '교육제도, 개혁 논의',
+    real: '교육제도 개혁에 대한 논의가 활발히 진행되고 있습니다.',
+    fake: '모든 학교를 폐쇄하고 교육을 금지한다고 발표했습니다.',
+  },
+};
+
+// 풀이 완료 상태: 제목, 진짜기사, 가짜기사, 사용자선택, 정답유무
+const dummySolvedQuizDetail: Record<string, {
+  title: string;
+  real: string;
+  fake: string;
+  userAnswer: 'real' | 'fake';
+  isCorrect: boolean;
+}> = {
+  '1': {
+    title: '정부, 새로운 정책 발표',
+    real: '정부는 오늘 새로운 정책을 공식 발표했습니다. 이번 정책은...',
+    fake: '정부는 오늘 모든 세금을 폐지한다고 발표했습니다. 이에 따라...',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '2': {
+    title: '주식시장, 사상 최고치 경신',
+    real: '오늘 주식시장은 사상 최고치를 기록하며 마감했습니다. 전문가들은...',
+    fake: '오늘 주식시장은 모든 종목이 상한가를 기록했습니다. 투자자들은...',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '3': {
+    title: 'AI, 일자리 대체 논란',
+    real: 'AI 기술의 발전으로 일자리 대체에 대한 우려가 커지고 있습니다.',
+    fake: 'AI가 모든 직업을 대체해 내일부터 모든 사람이 실직하게 됩니다.',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '4': {
+    title: '국회, 예산안 통과',
+    real: '국회에서 내년도 예산안이 통과되었습니다. 주요 내용은...',
+    fake: '국회에서 모든 예산을 폐지하고 무상복지만 실시한다고 발표했습니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '5': {
+    title: '금리 인상, 시장 영향',
+    real: '중앙은행의 금리 인상 결정으로 시장에 영향이 나타나고 있습니다.',
+    fake: '중앙은행이 모든 이자를 폐지하고 무이자 대출을 실시한다고 발표했습니다.',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '6': {
+    title: '기후변화, 극한 날씨 증가',
+    real: '전 세계적으로 기후변화로 인한 극한 날씨 현상이 증가하고 있습니다.',
+    fake: '내일부터 지구가 얼어붙어 모든 생명체가 멸종한다고 발표했습니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '7': {
+    title: '외교부, 새로운 협정 체결',
+    real: '외교부는 새로운 국가와의 협정을 체결했습니다. 협정 내용은...',
+    fake: '외교부가 모든 국가와의 외교관계를 단절한다고 발표했습니다.',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '8': {
+    title: '부동산 시장, 가격 변동',
+    real: '부동산 시장에서 가격 변동이 나타나고 있습니다. 전문가들은...',
+    fake: '정부가 모든 부동산을 무상으로 분배한다고 발표했습니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '9': {
+    title: '한류, 세계적 인기 확산',
+    real: '한류 문화가 전 세계적으로 인기를 얻고 있습니다. K팝과 K드라마는...',
+    fake: '한국 문화가 전 세계에서 금지되어 모든 한류 콘텐츠가 차단됩니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '10': {
+    title: '영화제, 새로운 작품 발표',
+    real: '국제영화제에서 새로운 작품들이 발표되었습니다. 주요 작품들은...',
+    fake: '영화제에서 모든 영화를 폐지하고 연극만 상영한다고 발표했습니다.',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '11': {
+    title: '전시회, 현대미술 전시',
+    real: '현대미술관에서 새로운 전시회가 열렸습니다. 전시 작품들은...',
+    fake: '모든 미술관을 폐쇄하고 그림 그리기를 금지한다고 발표했습니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '12': {
+    title: '새로운 AI 기술 개발',
+    real: '연구진이 새로운 AI 기술을 개발했습니다. 이 기술은...',
+    fake: 'AI가 모든 기술을 대체해 인간이 더 이상 발명할 수 없다고 발표했습니다.',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '13': {
+    title: '메타버스, 가상현실 발전',
+    real: '메타버스 기술이 발전하여 가상현실 경험이 향상되고 있습니다.',
+    fake: '메타버스가 현실을 완전히 대체해 모든 사람이 가상세계에 살게 됩니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+  '14': {
+    title: '블록체인, 기술 혁신',
+    real: '블록체인 기술의 혁신으로 다양한 분야에 적용되고 있습니다.',
+    fake: '블록체인이 모든 은행을 대체해 현금이 완전히 사라집니다.',
+    userAnswer: 'fake',
+    isCorrect: false,
+  },
+  '15': {
+    title: '교육제도, 개혁 논의',
+    real: '교육제도 개혁에 대한 논의가 활발히 진행되고 있습니다.',
+    fake: '모든 학교를 폐쇄하고 교육을 금지한다고 발표했습니다.',
+    userAnswer: 'real',
+    isCorrect: true,
+  },
+};
+
+export default function OxQuizDetailPage() {
+  const router = useRouter();
+  const [quiz, setQuiz] = useState<typeof dummyQuizDetail['1'] | typeof dummySolvedQuizDetail['1'] | null>(null);
+  const [selected, setSelected] = useState<'real' | 'fake' | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [currentQuizId, setCurrentQuizId] = useState<number | null>(null);
+  const [userQuizStatus, setUserQuizStatus] = useState<{ solved: boolean; isCorrect?: boolean; userAnswer?: 'real' | 'fake' } | null>(null);
+
+  useEffect(() => {
+    // 세션스토리지에서 선택된 퀴즈 정보 가져오기
+    const selectedQuizData = sessionStorage.getItem('selectedOxQuiz');
+    console.log('선택된 퀴즈 데이터:', selectedQuizData);
+    if (!selectedQuizData) {
+      router.push('/oxquiz');
+      return;
+    }
+
+    try {
+      const selectedQuiz = JSON.parse(selectedQuizData);
+      const quizId = selectedQuiz.id.toString();
+      setCurrentQuizId(selectedQuiz.id);
+      console.log('현재 퀴즈 ID:', selectedQuiz.id);
+      
+      // 로컬스토리지에서 사용자 퀴즈 상태 확인
+      const savedStatus = localStorage.getItem('userOxQuizStatus');
+      console.log('저장된 퀴즈 상태:', savedStatus);
+      let isSolved = false;
+      let solvedData = null;
+      
+      if (savedStatus) {
+        const allUserStatus = JSON.parse(savedStatus);
+        console.log('전체 사용자 상태:', allUserStatus);
+        const currentStatus = allUserStatus[selectedQuiz.id];
+        console.log('현재 퀴즈 상태:', currentStatus);
+        if (currentStatus?.solved) {
+          isSolved = true;
+          setUserQuizStatus(currentStatus);
+          console.log('퀴즈가 이미 풀린 상태입니다');
+          // 풀이 완료된 경우 서버에서 풀이 결과 포함된 데이터 요청
+          // 실제로는 fetch(`/api/oxquiz/detail/${quizId}?solved=true`)로 받아오세요
+          solvedData = dummySolvedQuizDetail[quizId];
+        }
+      }
+      
+      if (isSolved && solvedData) {
+        // 풀이 완료된 데이터 사용
+        console.log('풀이 완료된 데이터 사용:', solvedData);
+        setQuiz(solvedData);
+      } else {
+        // 미풀이 데이터 사용
+        console.log('미풀이 데이터 사용');
+        // 실제로는 fetch(`/api/oxquiz/detail/${quizId}`)로 받아오세요
+        const quizData = dummyQuizDetail[quizId];
+        if (!quizData) {
+          router.push('/oxquiz');
+          return;
+        }
+        setQuiz(quizData);
+      }
+      
+      setLoading(false);
+    } catch (error) {
+      console.error('퀴즈 데이터 파싱 오류:', error);
+      router.push('/oxquiz');
+    }
+  }, [router]);
+
+  if (loading) {
+    return <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3]">로딩 중...</div>;
+  }
+
+  if (!quiz) {
+    return <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3]">퀴즈를 찾을 수 없습니다.</div>;
+  }
+
+  const handleSubmit = () => {
+    if (!selected) return;
+    setSubmitted(true);
+    const correct = selected === 'real';
+    setIsCorrect(correct);
+    
+    // 실제로는 API로 정답 제출
+    // fetch(`/api/oxquiz/submit`, {
+    //   method: 'POST',
+    //   headers: { 'Content-Type': 'application/json' },
+    //   body: JSON.stringify({ quizId: currentQuizId, answer: selected })
+    // });
+    
+    // 메인페이지의 퀴즈 상태 업데이트
+    if (currentQuizId && (window as any).updateOxQuizStatus) {
+      (window as any).updateOxQuizStatus(currentQuizId, correct, selected);
+    }
+    
+    // 자동으로 메인페이지로 돌아가지 않음 - 사용자가 직접 나가도록 함
+  };
+
+  // 이미 푼 경우 결과 안내만
+  if (userQuizStatus?.solved) {
+    const solvedQuiz = quiz as typeof dummySolvedQuizDetail['1'];
+    const expGained = solvedQuiz.isCorrect ? 1 : 0;
+    const totalExp = 100 + expGained; // 임시 누적 경험치 (실제로는 DB에서 가져와야 함)
+    
+    return (
+      <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-8 px-4">
+        <div className="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-8 mb-10">
+          <div className="flex items-center justify-between mb-0">
+            <button
+              onClick={() => router.push('/oxquiz')}
+              className="flex items-center gap-2 px-4 py-2 text-[#2b6cb0] hover:text-[#1e40af] transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              <span className="font-semibold">OX퀴즈목록</span>
+            </button>
+          </div>
+          <h2 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] text-center">OX 퀴즈</h2>
+          <div className="bg-gradient-to-r from-[#e6f1fb] to-[#f7fafd] rounded-xl p-6 border border-[#e0e7ef] shadow-sm mt-8">
+            <div className="text-xl sm:text-2xl font-bold text-[#222] text-center">{solvedQuiz.title}</div>
+          </div>
+          <div className="flex flex-col lg:flex-row gap-6 w-full items-stretch justify-center">
+            <div
+              className={`flex-1 rounded-xl border-2 p-8 cursor-pointer transition-all shadow-sm min-h-[300px] flex flex-col
+                ${solvedQuiz.userAnswer === 'real' ? (solvedQuiz.isCorrect ? 'ring-2 ring-green-400 border-[#7f9cf5] bg-[#e6f0ff]' : 'ring-2 ring-red-400 border-[#e0e7ef] bg-[#f7fafd]') : 'border-[#e0e7ef] bg-[#f7fafd]'}
+              `}
+            >
+              <div className="font-semibold text-[#2b6cb0] mb-4 text-lg">뉴스 A</div>
+              <div className="text-base text-gray-800 whitespace-pre-line flex-1 leading-relaxed">{solvedQuiz.real}</div>
+            </div>
+            <div
+              className={`flex-1 rounded-xl border-2 p-8 cursor-pointer transition-all shadow-sm min-h-[300px] flex flex-col
+                ${solvedQuiz.userAnswer === 'fake' ? (!solvedQuiz.isCorrect ? 'ring-2 ring-green-400 border-[#7f9cf5] bg-[#e6f0ff]' : 'ring-2 ring-red-400 border-[#e0e7ef] bg-[#f7fafd]') : 'border-[#e0e7ef] bg-[#f7fafd]'}
+              `}
+            >
+              <div className="font-semibold text-[#2b6cb0] mb-4 text-lg">뉴스 B</div>
+              <div className="text-base text-gray-800 whitespace-pre-line flex-1 leading-relaxed">{solvedQuiz.fake}</div>
+            </div>
+          </div>
+          <div className={`text-center text-lg font-semibold mt-2 ${solvedQuiz.isCorrect ? 'text-green-600' : 'text-red-600'}`}>
+            {solvedQuiz.isCorrect
+              ? '정답! 진짜 뉴스(A)를 맞췄어요.'
+              : `오답! 진짜 뉴스는 A입니다. (내 답: ${solvedQuiz.userAnswer === 'real' ? 'A' : 'B'})`}
+          </div>
+          <div className="mt-4 text-center text-gray-500">이미 푼 퀴즈입니다.</div>
+          
+          {/* 경험치 정보 */}
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="bg-[#e6f1fb] rounded-xl p-4 flex flex-col items-center shadow">
+              <div className="text-xs text-gray-500 mb-1">OX퀴즈 경험치</div>
+              <div className="text-xl font-bold text-[#43e6b5]">+{expGained}점</div>
+            </div>
+            <div className="bg-[#f7fafd] rounded-xl p-4 flex flex-col items-center shadow">
+              <div className="text-xs text-gray-500 mb-1">나의 누적 경험치</div>
+              <div className="text-xl font-bold text-[#7f9cf5]">{totalExp}점</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 아직 안 푼 경우 기존 방식
+  return (
+    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-8 px-4">
+      <div className="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-8 mb-10">
+        <div className="flex items-center justify-between mb-0">
+          <button
+            onClick={() => router.push('/oxquiz')}
+            className="flex items-center gap-2 px-4 py-2 text-[#2b6cb0] hover:text-[#1e40af] transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            <span className="font-semibold">OX퀴즈목록</span>
+          </button>
+        </div>
+        <h2 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] text-center">OX 퀴즈</h2>
+        <div className="bg-gradient-to-r from-[#e6f1fb] to-[#f7fafd] rounded-xl p-6 border border-[#e0e7ef] shadow-sm mt-8">
+          <div className="text-xl sm:text-2xl font-bold text-[#222] text-center">{quiz.title}</div>
+        </div>
+        <div className="flex flex-col lg:flex-row gap-6 w-full items-stretch justify-center">
+          <div
+            onClick={() => !submitted && setSelected('real')}
+            className={`flex-1 rounded-xl border-2 p-8 cursor-pointer transition-all shadow-sm min-h-[300px] flex flex-col
+              ${selected === 'real' ? 'border-[#7f9cf5] bg-[#e6f0ff]' : 'border-[#e0e7ef] bg-[#f7fafd]'}
+              ${submitted && selected === 'real' && isCorrect === true ? 'ring-2 ring-green-400' : ''}
+              ${submitted && selected === 'real' && isCorrect === false ? 'ring-2 ring-red-400' : ''}
+            `}
+          >
+            <div className="font-semibold text-[#2b6cb0] mb-4 text-lg">뉴스 A</div>
+            <div className="text-base text-gray-800 whitespace-pre-line flex-1 leading-relaxed">{quiz.real}</div>
+          </div>
+          <div
+            onClick={() => !submitted && setSelected('fake')}
+            className={`flex-1 rounded-xl border-2 p-8 cursor-pointer transition-all shadow-sm min-h-[300px] flex flex-col
+              ${selected === 'fake' ? 'border-[#7f9cf5] bg-[#e6f0ff]' : 'border-[#e0e7ef] bg-[#f7fafd]'}
+              ${submitted && selected === 'fake' && isCorrect === false ? 'ring-2 ring-green-400' : ''}
+              ${submitted && selected === 'fake' && isCorrect === true ? 'ring-2 ring-red-400' : ''}
+            `}
+          >
+            <div className="font-semibold text-[#2b6cb0] mb-4 text-lg">뉴스 B</div>
+            <div className="text-base text-gray-800 whitespace-pre-line flex-1 leading-relaxed">{quiz.fake}</div>
+          </div>
+        </div>
+        <button
+          onClick={handleSubmit}
+          disabled={!selected || submitted}
+          className={`w-full py-3 rounded-full font-bold text-lg shadow transition
+            ${selected && !submitted ? 'bg-gradient-to-r from-[#7f9cf5] to-[#43e6b5] text-white hover:opacity-90' : 'bg-[#e6eaf3] text-gray-400 cursor-not-allowed'}`}
+        >
+          {submitted ? (isCorrect ? '정답입니다!' : '오답입니다!') : '제출'}
+        </button>
+        {submitted && (
+          <div className={`text-center text-lg font-semibold mt-2 ${isCorrect ? 'text-green-600' : 'text-red-600'}`}>
+            {isCorrect ? '정답! 진짜 뉴스(A)를 맞췄어요.' : '오답! 진짜 뉴스는 A입니다.'}
+          </div>
+        )}
+        {submitted && (
+          <div className="text-center text-sm text-gray-500 mt-2">
+            OX퀴즈목록으로 돌아가서 다른 퀴즈를 풀어보세요!
+          </div>
+        )}
+        
+        {/* 제출 후 경험치 정보 표시 */}
+        {submitted && (
+          <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="bg-[#e6f1fb] rounded-xl p-4 flex flex-col items-center shadow">
+              <div className="text-xs text-gray-500 mb-1">OX퀴즈 경험치</div>
+              <div className="text-xl font-bold text-[#43e6b5]">+{isCorrect ? 1 : 0}점</div>
+            </div>
+            <div className="bg-[#f7fafd] rounded-xl p-4 flex flex-col items-center shadow">
+              <div className="text-xs text-gray-500 mb-1">나의 누적 경험치</div>
+              <div className="text-xl font-bold text-[#7f9cf5]">{100 + (isCorrect ? 1 : 0)}점</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/src/app/oxquiz/page.tsx
+++ b/src/app/oxquiz/page.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+
+// 더미 카테고리/퀴즈 데이터
+const dummyCategories = [
+  { id: 'all', name: '전체' },
+  { id: 'politics', name: '정치' },
+  { id: 'culture', name: '문화' },
+  { id: 'it', name: 'IT' },
+  { id: 'economy', name: '경제' },
+  { id: 'society', name: '사회' },
+];
+
+const dummyQuizzes = [
+  { id: 1, category: 'politics', title: '정부, 새로운 정책 발표' },
+  { id: 2, category: 'economy', title: '주식시장, 사상 최고치 경신' },
+  { id: 3, category: 'society', title: 'AI, 일자리 대체 논란' },
+  { id: 4, category: 'politics', title: '국회, 예산안 통과' },
+  { id: 5, category: 'economy', title: '금리 인상, 시장 영향' },
+  { id: 6, category: 'society', title: '기후변화, 극한 날씨 증가' },
+  { id: 7, category: 'politics', title: '외교부, 새로운 협정 체결' },
+  { id: 8, category: 'economy', title: '부동산 시장, 가격 변동' },
+  { id: 9, category: 'culture', title: '한류, 세계적 인기 확산' },
+  { id: 10, category: 'culture', title: '영화제, 새로운 작품 발표' },
+  { id: 11, category: 'culture', title: '전시회, 현대미술 전시' },
+  { id: 12, category: 'it', title: '새로운 AI 기술 개발' },
+  { id: 13, category: 'it', title: '메타버스, 가상현실 발전' },
+  { id: 14, category: 'it', title: '블록체인, 기술 혁신' },
+  { id: 15, category: 'society', title: '교육제도, 개혁 논의' },
+];
+
+export default function OxQuizMainPage() {
+  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [userQuizStatus, setUserQuizStatus] = useState<Record<number, { solved: boolean; isCorrect?: boolean }>>({});
+
+  // 로컬스토리지에서 사용자 퀴즈 상태 불러오기
+  useEffect(() => {
+    const savedStatus = localStorage.getItem('userOxQuizStatus');
+    console.log('로드된 퀴즈 상태:', savedStatus);
+    if (savedStatus) {
+      try {
+        const parsedStatus = JSON.parse(savedStatus);
+        console.log('파싱된 퀴즈 상태:', parsedStatus);
+        setUserQuizStatus(parsedStatus);
+      } catch (error) {
+        console.error('퀴즈 상태 로드 오류:', error);
+      }
+    }
+  }, []);
+
+  const filteredQuizzes = selectedCategory === 'all'
+    ? dummyQuizzes
+    : dummyQuizzes.filter(q => q.category === selectedCategory);
+
+  const handleQuizClick = (quizId: number) => {
+    // 선택된 퀴즈 정보를 세션스토리지에 저장
+    const selectedQuiz = dummyQuizzes.find(q => q.id === quizId);
+    if (selectedQuiz) {
+      sessionStorage.setItem('selectedOxQuiz', JSON.stringify(selectedQuiz));
+    }
+  };
+
+  // 퀴즈 제출 후 상태 업데이트 (실제로는 API 응답 후 호출)
+  const updateQuizStatus = (quizId: number, isCorrect: boolean, userAnswer: 'real' | 'fake') => {
+    console.log('퀴즈 상태 업데이트 호출:', { quizId, isCorrect, userAnswer });
+    const newStatus = {
+      ...userQuizStatus,
+      [quizId]: { solved: true, isCorrect, userAnswer }
+    };
+    console.log('새로운 퀴즈 상태:', newStatus);
+    setUserQuizStatus(newStatus);
+    
+    // 로컬스토리지에 저장
+    localStorage.setItem('userOxQuizStatus', JSON.stringify(newStatus));
+    console.log('로컬스토리지에 저장됨:', localStorage.getItem('userOxQuizStatus'));
+  };
+
+  // 전역 함수로 등록 (다른 컴포넌트에서 호출 가능)
+  useEffect(() => {
+    (window as any).updateOxQuizStatus = updateQuizStatus;
+    return () => {
+      delete (window as any).updateOxQuizStatus;
+    };
+  }, [userQuizStatus]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-8 px-4">
+      <div className="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-8 mb-10">
+        <h1 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] mb-2 text-center">OX 퀴즈</h1>
+        <div className="flex flex-row gap-4 w-full justify-center mt-2 mb-6">
+          {dummyCategories.map((cat) => (
+            <button
+              key={cat.id}
+              onClick={() => setSelectedCategory(cat.id)}
+              className={`px-6 py-2 rounded-full border text-base font-semibold shadow transition-colors
+                ${selectedCategory === cat.id
+                  ? 'bg-gradient-to-r from-[#7f9cf5] to-[#43e6b5] text-white border-transparent'
+                  : 'bg-white/80 text-[#383838] border-[#e0e7ef] hover:bg-[#e0f7fa] hover:text-[#2b6cb0]'}`}
+            >
+              {cat.name}
+            </button>
+          ))}
+        </div>
+        <ul className="flex flex-col gap-4 w-full">
+          {filteredQuizzes.length === 0 && (
+            <li className="text-center text-gray-400 py-8">해당 카테고리의 퀴즈가 없습니다.</li>
+          )}
+          {filteredQuizzes.map(quiz => {
+            const status = userQuizStatus[quiz.id];
+            const isSolved = status?.solved;
+            const isCorrect = status?.isCorrect;
+            
+            return (
+              <li key={quiz.id} className="w-full">
+                <Link 
+                  href="/oxquiz/detail" 
+                  onClick={() => handleQuizClick(quiz.id)}
+                  className={`block w-full p-6 rounded-xl shadow hover:scale-[1.02] transition-transform border cursor-pointer
+                    ${isSolved 
+                      ? 'bg-gradient-to-r from-[#f0f9ff] to-[#e0f2fe] border-[#0ea5e9]' 
+                      : 'bg-gradient-to-r from-[#e6f1fb] to-[#f7fafd] border-[#e0e7ef]'
+                    }
+                  `}
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <span className="text-lg sm:text-xl font-bold text-[#222]">{quiz.title}</span>
+                      <span className="px-3 py-1 text-xs rounded-full bg-[#e6eaf3] text-[#2b6cb0] font-semibold">
+                        {dummyCategories.find(c => c.id === quiz.category)?.name}
+                      </span>
+                    </div>
+                    {isSolved && (
+                      <div className="flex items-center gap-2">
+                        <span className={`px-2 py-1 text-xs rounded-full font-semibold
+                          ${isCorrect 
+                            ? 'bg-green-100 text-green-700 border border-green-200' 
+                            : 'bg-red-100 text-red-700 border border-red-200'
+                          }
+                        `}>
+                          {isCorrect ? '정답' : '오답'}
+                        </span>
+                        <span className="text-xs text-gray-500">완료</span>
+                      </div>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+} 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,9 +9,9 @@ export default function Home() {
       <div className="flex flex-col items-center w-full gap-10 mt-2 pt-20">
         <div className="flex flex-row gap-8 w-full max-w-4xl justify-center">
           {/* 오늘의 뉴스 카드 */}
-          <div className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform">
+          <Link href="/todaynews" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer">
             <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
-          </div>
+          </Link>
           {/* OX 퀴즈 카드 */}
           <div className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform">
             <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">OX 퀴즈</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,9 +13,9 @@ export default function Home() {
             <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
           </Link>
           {/* OX 퀴즈 카드 */}
-          <div className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform">
+          <Link href="/oxquiz" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer">
             <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">OX 퀴즈</span>
-          </div>
+          </Link>
         </div>
         {/* 카테고리 버튼 */}
         <div className="flex flex-row gap-4 w-full max-w-2xl justify-center mt-14">

--- a/src/app/todaynews/page.tsx
+++ b/src/app/todaynews/page.tsx
@@ -13,8 +13,8 @@ export default function TodayNews() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-20 px-4">
-      <div className="w-full max-w-2xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-4 mb-10">
+    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-8 px-4">
+      <div className="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-4 mb-10">
         <h1 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] mb-2 text-center">오늘의 뉴스</h1>
         {news.image_url && (
           <div className="w-full flex justify-center mb-4">
@@ -29,7 +29,7 @@ export default function TodayNews() {
         </div>
         <div className="text-base text-gray-800 leading-relaxed whitespace-pre-line">{news.content}</div>
       </div>
-      <Link href="/todayquiz" className="w-full max-w-2xl">
+      <Link href="/todayquiz" className="w-full max-w-4xl">
         <button className="w-full py-3 rounded-full bg-gradient-to-r from-[#7f9cf5] to-[#43e6b5] text-white font-bold text-lg shadow hover:opacity-90 transition">
           오늘의 퀴즈 풀러가기
         </button>

--- a/src/app/todaynews/page.tsx
+++ b/src/app/todaynews/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+
+export default function TodayNews() {
+  // 예시 데이터 (실제 데이터 연동 시 교체)
+  const news = {
+    title: "AI가 만든 가짜뉴스와 진짜뉴스, 어떻게 구별할까?",
+    content: `최근 AI 기술의 발달로 가짜뉴스가 더욱 정교해지고 있습니다. 이에 따라 진짜뉴스와 가짜뉴스를 구별하는 것이 점점 더 중요해지고 있습니다. 전문가들은 출처 확인, 맥락 파악, AI 기반 진위 판별 서비스 활용 등을 권장합니다.`,
+    date: "2024-06-01",
+    reporter: "홍길동 기자",
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-20 px-4">
+      <div className="w-full max-w-2xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-4 mb-10">
+        <h1 className="text-2xl sm:text-3xl font-bold text-[#2b6cb0] mb-2">{news.title}</h1>
+        <div className="text-gray-500 text-sm mb-1">{news.date} · {news.reporter}</div>
+        <div className="text-base text-gray-800 leading-relaxed whitespace-pre-line">{news.content}</div>
+      </div>
+      <Link href="/todayquiz" className="w-full max-w-2xl">
+        <button className="w-full py-3 rounded-full bg-gradient-to-r from-[#7f9cf5] to-[#43e6b5] text-white font-bold text-lg shadow hover:opacity-90 transition">
+          오늘의 퀴즈 풀러가기
+        </button>
+      </Link>
+    </div>
+  );
+} 

--- a/src/app/todaynews/page.tsx
+++ b/src/app/todaynews/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 export default function TodayNews() {
   // 예시 데이터 (실제 데이터 연동 시 교체)
@@ -7,13 +8,25 @@ export default function TodayNews() {
     content: `최근 AI 기술의 발달로 가짜뉴스가 더욱 정교해지고 있습니다. 이에 따라 진짜뉴스와 가짜뉴스를 구별하는 것이 점점 더 중요해지고 있습니다. 전문가들은 출처 확인, 맥락 파악, AI 기반 진위 판별 서비스 활용 등을 권장합니다.`,
     date: "2024-06-01",
     reporter: "홍길동 기자",
+    source: "연합뉴스",
+    image_url: "https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=600&q=80",
   };
 
   return (
     <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-20 px-4">
       <div className="w-full max-w-2xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-4 mb-10">
-        <h1 className="text-2xl sm:text-3xl font-bold text-[#2b6cb0] mb-2">{news.title}</h1>
-        <div className="text-gray-500 text-sm mb-1">{news.date} · {news.reporter}</div>
+        <h1 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] mb-2 text-center">오늘의 뉴스</h1>
+        {news.image_url && (
+          <div className="w-full flex justify-center mb-4">
+            <Image src={news.image_url} alt="뉴스 이미지" width={600} height={300} className="rounded-xl object-cover max-h-60 w-auto" />
+          </div>
+        )}
+        <div className="text-2xl font-bold mb-2 text-center">{news.title}</div>
+        <div className="text-gray-500 text-sm mb-1 flex flex-wrap gap-2 items-center">
+          <span>{news.date}</span>
+          <span>· {news.reporter}</span>
+          <span className="px-2 py-0.5 bg-[#e6f1fb] rounded text-[#2b6cb0] font-semibold ml-2">{news.source}</span>
+        </div>
         <div className="text-base text-gray-800 leading-relaxed whitespace-pre-line">{news.content}</div>
       </div>
       <Link href="/todayquiz" className="w-full max-w-2xl">

--- a/src/app/todayquiz/page.tsx
+++ b/src/app/todayquiz/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+import { useState } from "react";
+
+// 임시(목업) 데이터: 오늘의 퀴즈 3문제
+const MOCK_QUIZZES = [
+  {
+    quiz_id: 101,
+    question: "AI가 만든 가짜뉴스와 진짜뉴스를 구별하는 방법은?",
+    option_a: "출처 확인",
+    option_b: "AI가 만든 뉴스만 읽기",
+    option_c: "아무거나 믿기",
+  },
+  {
+    quiz_id: 102,
+    question: "AI 뉴스의 위험성은?",
+    option_a: "정보의 신뢰성 저하",
+    option_b: "정보의 신뢰성 향상",
+    option_c: "정보가 없어짐",
+  },
+  {
+    quiz_id: 103,
+    question: "가짜뉴스를 판별하는 데 도움이 되는 것은?",
+    option_a: "AI 기반 진위 판별 서비스",
+    option_b: "카더라 통신",
+    option_c: "무작위 선택",
+  },
+];
+
+export default function TodayQuizPage() {
+  // 사용자의 선택 상태
+  const [answers, setAnswers] = useState<{ [quizId: number]: string }>({});
+  // 퀴즈 제출 결과 상태
+  const [result, setResult] = useState<null | {
+    details: { quiz_id: number; is_correct: boolean; user_answer: string; correct_option: string }[];
+    correct_count: number;
+    exp_gained: number;
+    total_exp: number;
+  }>(null);
+  const [showResult, setShowResult] = useState(false);
+
+  // 임시 정답 (실제 서버에서는 DailyQuiz에서 가져옴)
+  const CORRECT_OPTIONS: { [quizId: number]: string } = {
+    101: "option_a",
+    102: "option_a",
+    103: "option_a",
+  };
+
+  // 퀴즈 제출 핸들러 (임시 채점)
+  const handleSubmit = () => {
+    const details = MOCK_QUIZZES.map((q) => {
+      const user_answer = answers[q.quiz_id];
+      const correct_option = CORRECT_OPTIONS[q.quiz_id];
+      return {
+        quiz_id: q.quiz_id,
+        is_correct: user_answer === correct_option,
+        user_answer: user_answer || "",
+        correct_option,
+      };
+    });
+    const correct_count = details.filter((d) => d.is_correct).length;
+    const exp_gained = correct_count * 2;
+    const total_exp = 100 + exp_gained; // 임시 누적 경험치
+    setResult({ details, correct_count, exp_gained, total_exp });
+    setShowResult(true);
+  };
+
+  // 팝업 닫기
+  const handleCloseResult = () => {
+    setShowResult(false);
+    // 실제 서버 연동 시, 여기서 GET 요청을 다시 보내서 "이미 푼 퀴즈" UI로 리렌더링
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-20 px-4">
+      <div className="w-full max-w-2xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-8 mb-10">
+        <h1 className="text-2xl sm:text-3xl font-bold text-[#2b6cb0] mb-2">오늘의 퀴즈</h1>
+        {MOCK_QUIZZES.map((quiz, idx) => (
+          <div key={quiz.quiz_id} className="mb-4">
+            <div className="font-semibold mb-2">{idx + 1}. {quiz.question}</div>
+            <div className="flex flex-col gap-2">
+              {["option_a", "option_b", "option_c"].map((opt) => (
+                <label key={opt} className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="radio"
+                    name={`quiz_${quiz.quiz_id}`}
+                    value={opt}
+                    checked={answers[quiz.quiz_id] === opt}
+                    onChange={() => setAnswers((prev) => ({ ...prev, [quiz.quiz_id]: opt }))}
+                    disabled={!!result}
+                  />
+                  <span>{quiz[opt as "option_a" | "option_b" | "option_c"]}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+        ))}
+        {!result && (
+          <button
+            className="w-full py-3 rounded-full bg-gradient-to-r from-[#7f9cf5] to-[#43e6b5] text-white font-bold text-lg shadow hover:opacity-90 transition"
+            onClick={handleSubmit}
+            disabled={Object.keys(answers).length !== 3}
+          >
+            퀴즈 제출
+          </button>
+        )}
+      </div>
+
+      {/* 결과 팝업 */}
+      {showResult && result && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/30 z-50">
+          <div className="bg-white rounded-2xl shadow-lg p-8 w-full max-w-md flex flex-col gap-4">
+            <h2 className="text-xl font-bold text-[#2b6cb0] mb-2">퀴즈 결과</h2>
+            {result.details.map((d, idx) => (
+              <div key={d.quiz_id} className="flex flex-col mb-2">
+                <span>
+                  {idx + 1}번 문제: {d.is_correct ? "정답" : "오답"}
+                  <span className="ml-2 text-sm text-gray-500">
+                    (내 답: {MOCK_QUIZZES[idx][d.user_answer as "option_a" | "option_b" | "option_c"] || "-"}
+                    { !d.is_correct && (
+                      <> / 정답: {MOCK_QUIZZES[idx][d.correct_option as "option_a" | "option_b" | "option_c"]}</>
+                    )}
+                    )
+                  </span>
+                </span>
+              </div>
+            ))}
+            <div className="mt-2 font-semibold">
+              총 정답: {result.correct_count} / 3<br />
+              이번에 얻은 경험치: {result.exp_gained}점<br />
+              누적 경험치: {result.total_exp}점
+            </div>
+            <button
+              className="mt-4 w-full py-2 rounded-full bg-gradient-to-r from-[#7f9cf5] to-[#43e6b5] text-white font-bold shadow hover:opacity-90 transition"
+              onClick={handleCloseResult}
+            >
+              확인
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+} 

--- a/src/app/todayquiz/page.tsx
+++ b/src/app/todayquiz/page.tsx
@@ -85,8 +85,8 @@ export default function TodayQuizPage() {
   // 퀴즈 완료 후 보여줄 UI
   if (quizCompleted && result) {
     return (
-      <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-20 px-4">
-        <div className="w-full max-w-2xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-8 mb-10">
+      <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-8 px-4">
+        <div className="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8 flex flex-col gap-8 mb-10">
           {NewsInfoCard}
           <h1 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] text-center flex items-center justify-center gap-2 mb-6">
             오늘의 퀴즈
@@ -98,7 +98,6 @@ export default function TodayQuizPage() {
               <div key={quiz.quiz_id} className="mb-4 w-full pb-4 border-b border-[#e6eaf3] bg-[#f7fafd] rounded-xl">
                 <div className="font-bold text-lg mb-2 flex items-center justify-center gap-2">
                   <span>{idx + 1}. {quiz.question}</span>
-                  <span className={`text-sm font-semibold ml-2 ${d.is_correct ? "text-green-600" : "text-red-600"}`}>{d.is_correct ? "정답" : "오답"}</span>
                 </div>
                 <div className="flex flex-col gap-2 items-center justify-center text-center">
                   {["option_a", "option_b", "option_c"].map((opt) => {
@@ -147,8 +146,8 @@ export default function TodayQuizPage() {
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-20 px-4">
-      <div className="w-full max-w-2xl bg-white rounded-2xl shadow-lg p-8 flex flex-col items-center gap-8 mb-10">
+    <div className="min-h-screen flex flex-col items-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] pt-8 px-4">
+      <div className="w-full max-w-4xl bg-white rounded-2xl shadow-lg p-8 flex flex-col items-center gap-8 mb-10">
         {NewsInfoCard}
         <h1 className="text-3xl sm:text-4xl font-extrabold text-[#2b6cb0] mb-3 text-center">오늘의 퀴즈</h1>
         <div className="w-full flex flex-col items-center">


### PR DESCRIPTION
페이지 4개 구현 완료 (서버 연결만 하면 됩니다!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * OX 퀴즈 메인 페이지와 상세 페이지가 추가되어 퀴즈 풀이 및 결과 확인이 가능합니다.
  * 오늘의 뉴스 페이지가 추가되어 주요 뉴스를 확인할 수 있습니다.
  * 오늘의 뉴스 기반 퀴즈 페이지가 추가되어 뉴스 관련 문제를 풀고 결과 및 경험치 획득이 가능합니다.

* **기능 개선**
  * 메인 화면의 카드가 클릭 시 각 기능 페이지로 이동할 수 있도록 개선되었습니다.
  * 로그인 페이지에서 카카오 소셜 로그인 버튼 및 회원가입 링크의 스타일이 개선되었습니다.

* **스타일**
  * 글로벌 CSS에서 테마 관련 코드가 통합되어 변수 관리가 간소화되었습니다.

* **설정**
  * 외부 이미지 도메인(images.unsplash.com) 허용 설정이 추가되어 이미지 최적화 기능이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->