### PR TITLE
[feat] 소셜로그인(카카오,구글,네이버) 완료

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,19 @@ import type { NextConfig } from "next";
 
 const nextConfig = {
   images: {
+<<<<<<< HEAD
     domains: [
       'images.unsplash.com', // 사용하는 외부 이미지 도메인
       'imgnews.pstatic.net', // 네이버 뉴스 이미지 도메인 추가
+=======
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+        port: '',
+        pathname: '/**',
+      },
+>>>>>>> e757bc3 (feat: 카카오 소셜로그인 완료)
     ],
   },
   async rewrites() {

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,11 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig = {
   images: {
-<<<<<<< HEAD
-    domains: [
-      'images.unsplash.com', // 사용하는 외부 이미지 도메인
-      'imgnews.pstatic.net', // 네이버 뉴스 이미지 도메인 추가
-=======
     remotePatterns: [
       {
         protocol: 'https',
@@ -14,7 +9,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
->>>>>>> e757bc3 (feat: 카카오 소셜로그인 완료)
+      {
+        protocol: 'https',
+        hostname: 'imgnews.pstatic.net',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
   async rewrites() {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -136,13 +136,16 @@ export default function LoginPage() {
           <Image src="/social/naver_login.png" alt="네이버 로고" width={24} height={24} className="group-hover:opacity-80 transition" />
           <span>네이버로 로그인</span>
         </button>
-        
+
         {/* 구글 소셜로그인 */}
-        <button type="button" className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FFFFFF] border border-gray-300 text-[#3c4043] hover:bg-gray-50 transition mb-1">
+        <a 
+          href="http://localhost:8080/oauth2/authorization/google?redirectUrl=http://localhost:3000/"
+          className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FFFFFF] border border-gray-300 text-[#3c4043] hover:bg-gray-50 transition mb-1"
+        >
           <Image src="/social/google_login.png" alt="구글 로고" width={24} height={24} className="ml-[-13px] group-hover:opacity-80 transition" />
           <span>구글로 로그인</span>
-        </button>
-        
+        </a>  
+
         {/* 카카오 소셜로그인 */}
         <a 
           href="http://localhost:8080/oauth2/authorization/kakao?redirectUrl=http://localhost:3000/"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -132,10 +132,13 @@ export default function LoginPage() {
         </div>
         
         {/* 네이버 소셜로그인 */}
-        <button type="button" className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#03C75A] text-white hover:opacity-90 transition mb-1">
+        <a 
+          href="http://localhost:8080/oauth2/authorization/naver?redirectUrl=http://localhost:3000/"
+          className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#03C75A] text-white hover:opacity-90 transition mb-1"
+        >
           <Image src="/social/naver_login.png" alt="네이버 로고" width={24} height={24} className="group-hover:opacity-80 transition" />
           <span>네이버로 로그인</span>
-        </button>
+        </a>  
 
         {/* 구글 소셜로그인 */}
         <a 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -144,10 +144,13 @@ export default function LoginPage() {
         </button>
         
         {/* 카카오 소셜로그인 */}
-        <button type="button" className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FEE500] text-[#3C1E1E] hover:bg-[#FFEB3B] transition mb-1">
+        <a 
+          href="http://localhost:8080/oauth2/authorization/kakao"
+          className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FEE500] text-[#3C1E1E] hover:bg-[#FFEB3B] transition mb-1"
+        >
           <Image src="/social/kakao_login.png" alt="카카오 로고" width={24} height={24} className="group-hover:opacity-70 transition" />
           <span>카카오로 로그인</span>
-        </button>
+        </a>  
         
         <Link href="/register" className="mt-4 text-center text-[#2b6cb0] font-semibold hover:underline">
           회원가입하기

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -145,7 +145,7 @@ export default function LoginPage() {
         
         {/* 카카오 소셜로그인 */}
         <a 
-          href="http://localhost:8080/oauth2/authorization/kakao"
+          href="http://localhost:8080/oauth2/authorization/kakao?redirectUrl=http://localhost:3000/"
           className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FEE500] text-[#3C1E1E] hover:bg-[#FFEB3B] transition mb-1"
         >
           <Image src="/social/kakao_login.png" alt="카카오 로고" width={24} height={24} className="group-hover:opacity-70 transition" />

--- a/src/app/oxquiz/detail/[id]/page.tsx
+++ b/src/app/oxquiz/detail/[id]/page.tsx
@@ -202,8 +202,15 @@ const dummySolvedQuizDetail: Record<string, {
   },
 };
 
-export default function OxQuizDetailPage() {
+interface PageProps {
+  params: {
+    id: string;
+  };
+}
+
+export default function OxQuizDetailPage({ params }: PageProps) {
   const router = useRouter();
+  const { id } = params;
   const [quiz, setQuiz] = useState<typeof dummyQuizDetail['1'] | typeof dummySolvedQuizDetail['1'] | null>(null);
   const [selected, setSelected] = useState<'real' | 'fake' | null>(null);
   const [submitted, setSubmitted] = useState(false);
@@ -213,63 +220,49 @@ export default function OxQuizDetailPage() {
   const [userQuizStatus, setUserQuizStatus] = useState<{ solved: boolean; isCorrect?: boolean; userAnswer?: 'real' | 'fake' } | null>(null);
 
   useEffect(() => {
-    // 세션스토리지에서 선택된 퀴즈 정보 가져오기
-    const selectedQuizData = sessionStorage.getItem('selectedOxQuiz');
-    console.log('선택된 퀴즈 데이터:', selectedQuizData);
-    if (!selectedQuizData) {
-      router.push('/oxquiz');
-      return;
-    }
-
-    try {
-      const selectedQuiz = JSON.parse(selectedQuizData);
-      const quizId = selectedQuiz.id.toString();
-      setCurrentQuizId(selectedQuiz.id);
-      console.log('현재 퀴즈 ID:', selectedQuiz.id);
-      
-      // 로컬스토리지에서 사용자 퀴즈 상태 확인
-      const savedStatus = localStorage.getItem('userOxQuizStatus');
-      console.log('저장된 퀴즈 상태:', savedStatus);
-      let isSolved = false;
-      let solvedData = null;
-      
-      if (savedStatus) {
-        const allUserStatus = JSON.parse(savedStatus);
-        console.log('전체 사용자 상태:', allUserStatus);
-        const currentStatus = allUserStatus[selectedQuiz.id];
-        console.log('현재 퀴즈 상태:', currentStatus);
-        if (currentStatus?.solved) {
-          isSolved = true;
-          setUserQuizStatus(currentStatus);
-          console.log('퀴즈가 이미 풀린 상태입니다');
-          // 풀이 완료된 경우 서버에서 풀이 결과 포함된 데이터 요청
-          // 실제로는 fetch(`/api/oxquiz/detail/${quizId}?solved=true`)로 받아오세요
-          solvedData = dummySolvedQuizDetail[quizId];
-        }
+    const quizId = id;
+    setCurrentQuizId(parseInt(quizId));
+    console.log('현재 퀴즈 ID:', quizId);
+    
+    // 로컬스토리지에서 사용자 퀴즈 상태 확인
+    const savedStatus = localStorage.getItem('userOxQuizStatus');
+    console.log('저장된 퀴즈 상태:', savedStatus);
+    let isSolved = false;
+    let solvedData = null;
+    
+    if (savedStatus) {
+      const allUserStatus = JSON.parse(savedStatus);
+      console.log('전체 사용자 상태:', allUserStatus);
+      const currentStatus = allUserStatus[quizId];
+      console.log('현재 퀴즈 상태:', currentStatus);
+      if (currentStatus?.solved) {
+        isSolved = true;
+        setUserQuizStatus(currentStatus);
+        console.log('퀴즈가 이미 풀린 상태입니다');
+        // 풀이 완료된 경우 서버에서 풀이 결과 포함된 데이터 요청
+        // 실제로는 fetch(`/api/oxquiz/detail/${quizId}?solved=true`)로 받아오세요
+        solvedData = dummySolvedQuizDetail[quizId];
       }
-      
-      if (isSolved && solvedData) {
-        // 풀이 완료된 데이터 사용
-        console.log('풀이 완료된 데이터 사용:', solvedData);
-        setQuiz(solvedData);
-      } else {
-        // 미풀이 데이터 사용
-        console.log('미풀이 데이터 사용');
-        // 실제로는 fetch(`/api/oxquiz/detail/${quizId}`)로 받아오세요
-        const quizData = dummyQuizDetail[quizId];
-        if (!quizData) {
-          router.push('/oxquiz');
-          return;
-        }
-        setQuiz(quizData);
-      }
-      
-      setLoading(false);
-    } catch (error) {
-      console.error('퀴즈 데이터 파싱 오류:', error);
-      router.push('/oxquiz');
     }
-  }, [router]);
+    
+    if (isSolved && solvedData) {
+      // 풀이 완료된 데이터 사용
+      console.log('풀이 완료된 데이터 사용:', solvedData);
+      setQuiz(solvedData);
+    } else {
+      // 미풀이 데이터 사용
+      console.log('미풀이 데이터 사용');
+      // 실제로는 fetch(`/api/oxquiz/detail/${quizId}`)로 받아오세요
+      const quizData = dummyQuizDetail[quizId];
+      if (!quizData) {
+        router.push('/oxquiz');
+        return;
+      }
+      setQuiz(quizData);
+    }
+    
+    setLoading(false);
+  }, [id, router]);
 
   if (loading) {
     return <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3]">로딩 중...</div>;

--- a/src/app/oxquiz/page.tsx
+++ b/src/app/oxquiz/page.tsx
@@ -54,13 +54,7 @@ export default function OxQuizMainPage() {
     ? dummyQuizzes
     : dummyQuizzes.filter(q => q.category === selectedCategory);
 
-  const handleQuizClick = (quizId: number) => {
-    // 선택된 퀴즈 정보를 세션스토리지에 저장
-    const selectedQuiz = dummyQuizzes.find(q => q.id === quizId);
-    if (selectedQuiz) {
-      sessionStorage.setItem('selectedOxQuiz', JSON.stringify(selectedQuiz));
-    }
-  };
+
 
   // 퀴즈 제출 후 상태 업데이트 (실제로는 API 응답 후 호출)
   const updateQuizStatus = (quizId: number, isCorrect: boolean, userAnswer: 'real' | 'fake') => {
@@ -115,8 +109,7 @@ export default function OxQuizMainPage() {
             return (
               <li key={quiz.id} className="w-full">
                 <Link 
-                  href="/oxquiz/detail" 
-                  onClick={() => handleQuizClick(quiz.id)}
+                  href={`/oxquiz/detail/${quiz.id}`}
                   className={`block w-full p-6 rounded-xl shadow hover:scale-[1.02] transition-transform border cursor-pointer
                     ${isSolved 
                       ? 'bg-gradient-to-r from-[#f0f9ff] to-[#e0f2fe] border-[#0ea5e9]' 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+<<<<<<< HEAD
 import Image from "next/image";
 import Link from "next/link";
 import React, { useEffect, useState } from "react";
@@ -36,6 +37,25 @@ export default function Home() {
     };
     fetchTodayNews();
   }, []);
+=======
+
+import Image from "next/image";
+import Link from "next/link";
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+export default function Home() {
+  const searchParams = useSearchParams();
+  
+  useEffect(() => {
+    const loginSuccess = searchParams.get('loginSuccess');
+    const message = searchParams.get('message');
+    
+    if (loginSuccess === 'true' && message) {
+      alert(message); // 카카오 로그인 성공 메시지 팝업
+    }
+  }, [searchParams]);
+>>>>>>> e757bc3 (feat: 카카오 소셜로그인 완료)
 
   return (
     <div className="font-sans min-h-screen bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] flex flex-col items-center relative">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,4 @@
 "use client";
-<<<<<<< HEAD
-import Image from "next/image";
-import Link from "next/link";
-import React, { useEffect, useState } from "react";
-
-interface TodayNews {
-  id: number;
-  title: string;
-  imgUrl?: string;
-}
-
-export default function Home() {
-  const [todayNews, setTodayNews] = useState<TodayNews | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchTodayNews = async () => {
-      try {
-        const res = await fetch("/api/news/today");
-        if (!res.ok) return;
-        const data = await res.json();
-        if (data.code === 200 && data.data) {
-          setTodayNews({
-            id: data.data.id,
-            title: data.data.title,
-            imgUrl: data.data.imgUrl || "",
-          });
-        } else {
-          setTodayNews(null);
-        }
-      } catch {
-        setTodayNews(null);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchTodayNews();
-  }, []);
-=======
 
 import Image from "next/image";
 import Link from "next/link";
@@ -55,7 +16,6 @@ export default function Home() {
       alert(message); // 카카오 로그인 성공 메시지 팝업
     }
   }, [searchParams]);
->>>>>>> e757bc3 (feat: 카카오 소셜로그인 완료)
 
   return (
     <div className="font-sans min-h-screen bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] flex flex-col items-center relative">
@@ -64,32 +24,8 @@ export default function Home() {
       <div className="flex flex-col items-center w-full gap-10 mt-2 pt-20">
         <div className="flex flex-row gap-8 w-full max-w-4xl justify-center">
           {/* 오늘의 뉴스 카드 */}
-          <Link href="/todaynews" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer overflow-hidden relative group">
-            {loading ? (
-              <span className="text-2xl text-white">로딩 중...</span>
-            ) : todayNews && todayNews.imgUrl ? (
-              <>
-                <Image
-                  src={todayNews.imgUrl}
-                  alt="오늘의 뉴스 이미지"
-                  fill
-                  className="object-cover w-full h-full absolute top-0 left-0 z-0 transition-transform group-hover:scale-105"
-                  style={{ filter: 'brightness(0.7)' }}
-                  priority
-                />
-                {/* 하단 그라데이션 오버레이 */}
-                <div className="absolute left-0 right-0 bottom-0 h-2/5 bg-gradient-to-t from-black/70 to-transparent z-10" />
-                <span className="z-20 absolute left-0 right-0 bottom-0 pb-4 text-2xl sm:text-3xl font-extrabold text-white drop-shadow-md text-center px-2 line-clamp-2">
-                  {todayNews.title}
-                </span>
-              </>
-            ) : todayNews ? (
-              <span className="text-2xl sm:text-3xl font-extrabold text-white drop-shadow-md text-center px-2 line-clamp-2">
-                {todayNews.title}
-              </span>
-            ) : (
-              <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
-            )}
+          <Link href="/todaynews" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer">
+            <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
           </Link>
           {/* OX 퀴즈 카드 */}
           <Link href="/oxquiz" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer">


### PR DESCRIPTION
카카오 소셜로그인 버튼 누르면 카카오 소셜로그인 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 소셜 로그인 버튼이 OAuth2 인증 URL로 직접 연결되는 링크로 변경되었습니다.
  * 퀴즈 상세 페이지가 세션 저장소 대신 URL 파라미터를 통해 퀴즈 ID를 인식하도록 개선되었습니다.

* **버그 수정**
  * 퀴즈 목록에서 퀴즈 선택 시 세션 저장소를 사용하지 않고, 동적 URL로 상세 페이지에 접근하도록 변경되었습니다.

* **리팩터**
  * 메인 페이지(Home)가 더 이상 뉴스 데이터를 관리하거나 표시하지 않고, 로그인 성공 시 URL 파라미터를 감지하여 알림만 표시하도록 단순화되었습니다.
  * 외부 이미지 소스 설정이 도메인 배열에서 패턴 기반 설정으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->