### PR TITLE
[refactor] 메인페이지 오늘의뉴스 이미지,제목 표시

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,9 +6,9 @@
   <component name="ChangeListManager">
     <list default="true" id="181c4937-138a-40e3-b22f-fe5e6b158d0c" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/next.config.ts" beforeDir="false" afterPath="$PROJECT_DIR$/next.config.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/admin/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/admin/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/mypage/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/mypage/page.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/app/news/[id]/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/news/[id]/page.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/app/news/[id]/quiz/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/news/[id]/quiz/page.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/app/page.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/app/page.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -61,7 +61,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager": "true",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "maintoday",
+    "git-widget-placeholder": "mainpage",
     "ignore.virus.scanning.warn.message": "true",
     "js.debugger.nextJs.config.created.client": "true",
     "js.debugger.nextJs.config.created.server": "true",

--- a/next.config.ts
+++ b/next.config.ts
@@ -57,6 +57,12 @@ const nextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'placehold.co',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
   async rewrites() {

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -81,7 +81,7 @@ export default function AdminPage() {
       setNewsLoading(true);
       setNewsError(null);
       try {
-        const res = await fetch("/api/news?page=1&size=10&direction=desc");
+        const res = await fetch("/api/news?page=1&size=50&direction=desc");
         if (!res.ok) throw new Error("뉴스 목록 조회 실패");
         const data = await res.json();
         setNews(data.data.content || []);
@@ -159,7 +159,7 @@ export default function AdminPage() {
       <div className="absolute bottom-20 right-20 w-40 h-40 bg-gradient-to-br from-[#bfe0f5]/30 to-[#8fa4c3]/30 rounded-full blur-xl animate-pulse delay-1000"></div>
       <div className="absolute top-1/2 left-10 w-24 h-24 bg-gradient-to-br from-[#43e6b5]/25 to-[#7f9cf5]/25 rounded-full blur-lg animate-bounce"></div>
       
-      <div className="w-full max-w-7xl bg-white/90 rounded-3xl shadow-2xl p-12 flex flex-col gap-12 items-center relative overflow-hidden">
+      <div className="w-full max-w-8xl bg-white/90 rounded-3xl shadow-2xl p-12 flex flex-col gap-12 items-center relative overflow-hidden">
         {/* 상단 장식 라인 */}
         <div className="absolute top-0 left-0 right-0 h-2 bg-gradient-to-r from-[#7f9cf5] via-[#43e6b5] to-[#7f9cf5]"></div>
         

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -15,7 +15,7 @@ interface MemberInfo {
 }
 
 export default function MyPage() {
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, checkAuth } = useAuth();
   const router = useRouter();
   const [memberInfo, setMemberInfo] = useState<MemberInfo | null>(null);
   const [loading, setLoading] = useState(true);
@@ -25,14 +25,23 @@ export default function MyPage() {
 
   // 인증 확인 및 회원 정보 조회
   useEffect(() => {
-    if (!isAuthenticated) {
-      alert('로그인이 필요합니다.');
-      router.replace('/login');
-      return;
-    }
+    const checkAuthAndFetchInfo = async () => {
+      // 먼저 인증 상태를 다시 확인
+      await checkAuth();
+      
+      // 인증이 되지 않은 경우
+      if (!isAuthenticated) {
+        alert('로그인이 필요합니다.');
+        router.replace('/login');
+        return;
+      }
 
-    fetchMemberInfo();
-  }, [isAuthenticated, router]);
+      // 인증된 경우 회원 정보 조회
+      fetchMemberInfo();
+    };
+
+    checkAuthAndFetchInfo();
+  }, []);
 
   // 퀴즈 완료 이벤트 감지하여 정보 새로고침
   useEffect(() => {

--- a/src/app/news/[id]/quiz/page.tsx
+++ b/src/app/news/[id]/quiz/page.tsx
@@ -72,49 +72,22 @@ export default function NewsQuizPage() {
 
   const handleSubmit = async () => {
     try {
-      // 각 퀴즈에 대해 백엔드에 히스토리 생성 요청 (실제 경험치 지급)
-      const historyPromises = quizzes.map(async (quiz, idx) => {
-        const user_answer = answers[idx];
-        if (!user_answer) return null;
-
-        const res = await fetch('/api/histories', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            quizId: parseInt(newsId as string) * 100 + idx + 1, // 뉴스ID * 100 + 퀴즈 인덱스로 고유 ID 생성
-            quizType: 'DETAIL',
-            answer: user_answer
-          })
-        });
-
-        if (!res.ok) {
-          throw new Error('퀴즈 제출에 실패했습니다.');
-        }
-
-        return await res.json();
-      });
-
-      const historyResults = await Promise.all(historyPromises);
-      
-      // 결과 계산
+      // 프론트엔드에서만 결과 계산 (백엔드 API 호출 없음)
       const details = quizzes.map((q, idx) => {
         const user_answer = answers[idx];
         const correct_option = q.correctOption;
-        const historyResult = historyResults[idx];
         
         return {
           idx,
           is_correct: user_answer === correct_option,
           user_answer: user_answer || "",
           correct_option,
+          gainExp: user_answer === correct_option ? 100 : 0 // 정답이면 100점, 오답이면 0점
         };
       });
       
       const correct_count = details.filter((d) => d.is_correct).length;
-      const exp_gained = correct_count * 100; // 백엔드에서 정답당 100점 지급
+      const exp_gained = details.reduce((sum, d) => sum + d.gainExp, 0); // 총 획득 경험치
       const total_exp = 100 + exp_gained; // 임시 누적 경험치
       
       setResult({ details, correct_count, exp_gained, total_exp });
@@ -131,6 +104,11 @@ export default function NewsQuizPage() {
     
     // 퀴즈 완료 후 마이페이지 정보 새로고침을 위한 이벤트 발생
     window.dispatchEvent(new CustomEvent('quizCompleted'));
+    
+    // 잠시 후 메인페이지로 리다이렉트 (선택사항)
+    setTimeout(() => {
+      window.location.href = '/';
+    }, 2000);
   };
 
   // 뉴스 정보 카드

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,19 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useAuth } from "@/contexts/AuthContext";
+
+interface TodayNews {
+  id: number;
+  title: string;
+  content: string;
+  originCreatedDate: string;
+  journalist: string;
+  mediaName: string;
+  imgUrl?: string;
+}
 
 interface NewsArticle {
   id: number;
@@ -52,6 +62,27 @@ export default function Home() {
       checkAuth();
     }
   }, [searchParams, checkAuth]);
+
+  // 오늘의 뉴스 불러오기
+  useEffect(() => {
+    const fetchTodayNews = async () => {
+      try {
+        const res = await fetch('/api/news/today');
+        if (res.ok) {
+          const data = await res.json();
+          if (data.code === 200 && data.data) {
+            setTodayNews(data.data);
+          }
+        }
+      } catch (error) {
+        console.error('오늘의 뉴스 조회 실패:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchTodayNews();
+  }, []);
 
   // 뉴스 기사 목록 불러오기
   useEffect(() => {
@@ -112,8 +143,35 @@ export default function Home() {
       <div className="flex flex-col items-center w-full gap-10 mt-2 pt-20">
         <div className="flex flex-row gap-8 w-full max-w-4xl justify-center">
           {/* 오늘의 뉴스 카드 */}
-          <Link href="/todaynews" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer">
-            <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
+          <Link href="/todaynews" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex flex-col items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer overflow-hidden relative">
+            {loading ? (
+              <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
+            ) : todayNews ? (
+              <>
+                {/* 배경 이미지 */}
+                {todayNews.imgUrl && (
+                  <div className="absolute inset-0 z-0">
+                    <Image
+                      src={todayNews.imgUrl}
+                      alt="오늘의 뉴스"
+                      fill
+                      className="object-cover"
+                    />
+                  </div>
+                )}
+                {/* 뉴스 정보 - 제목을 아래에 배치 */}
+                <div className="relative z-10 flex flex-col items-center justify-end text-center px-4 pb-6 h-full">
+                  <div className="text-lg sm:text-xl font-bold text-white drop-shadow-md mb-2 line-clamp-2">
+                    {todayNews.title}
+                  </div>
+                  <div className="text-sm text-white/90 drop-shadow-sm">
+                    {todayNews.mediaName} • {new Date(todayNews.originCreatedDate).toLocaleDateString()}
+                  </div>
+                </div>
+              </>
+            ) : (
+              <span className="text-3xl sm:text-4xl font-extrabold text-white drop-shadow-md">오늘의 뉴스</span>
+            )}
           </Link>
           {/* OX 퀴즈 카드 */}
           <Link href="/oxquiz" className="flex-1 min-w-[260px] max-w-[400px] h-[180px] rounded-3xl bg-gradient-to-b from-[#bfe0f5] via-[#8fa4c3] via-70% to-[#e6f1fb] flex items-center justify-center shadow-lg hover:scale-105 transition-transform cursor-pointer">


### PR DESCRIPTION
관리자 페이지에서 오늘의 뉴스 설정하면 이미지,제목 표시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 홈 화면에 "오늘의 뉴스"를 표시하는 기능이 추가되었습니다.

* **버그 수정**
  * 마이페이지에서 인증 상태를 새로 확인한 후 사용자 정보를 가져오도록 개선되었습니다.

* **기능 개선**
  * 어드민 페이지에서 한 번에 더 많은 뉴스 목록(10개 → 50개)을 볼 수 있도록 변경되었습니다.
  * 어드민 페이지의 최대 폭이 넓어져 더 많은 내용을 한눈에 볼 수 있습니다.
  * 퀴즈 결과 계산이 프론트엔드에서 처리되어, 제출 후 2초 뒤 메인 페이지로 자동 이동됩니다.
  * 외부 이미지 소스로 placehold.co 도메인이 허용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->