### PR TITLE
네이버 소셜로그인 프래그먼트 처리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "next": "15.4.3",
+        "next": "^15.4.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-icons": "^5.5.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.4.3",
+    "next": "^15.4.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-icons": "^5.5.0"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,6 +91,29 @@ function SearchParamsHandler() {
     }
   }, [searchParams, checkAuth]);
 
+  // 프래그먼트 처리 (네이버 OAuth 콜백용)
+  useEffect(() => {
+    const handleFragment = () => {
+      const hash = window.location.hash;
+      if (hash && hash.startsWith('#')) {
+        // 프래그먼트가 있으면 소셜 로그인 성공으로 간주
+        console.log('소셜 로그인 콜백 감지:', hash);
+        
+        // 사용자 정보 새로고침
+        checkAuth();
+        
+        // 프래그먼트 제거 (URL 정리)
+        window.history.replaceState(null, '', window.location.pathname);
+        
+        // 성공 메시지 표시
+        alert('소셜 로그인이 완료되었습니다!');
+      }
+    };
+
+    // 페이지 로드 시 프래그먼트 확인
+    handleFragment();
+  }, [checkAuth]);
+
   return null; // UI는 렌더링하지 않음
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Naver 소셜 로그인 완료 시 URL에 해시(#)가 포함된 경우를 처리하여, 인증 상태를 갱신하고 안내 메시지를 표시하도록 개선되었습니다.

* **Chores**
  * "next" 패키지 의존성 버전 범위가 유연하게 변경되어, 향후 마이너 및 패치 업데이트를 자동으로 적용할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->