### PR TITLE
[refactor] mypage 바 텍스트 수정

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -210,6 +210,13 @@ export default function MyPage() {
   };
 
   const expPercent = calculateExpPercent(memberInfo.exp, memberInfo.level);
+  // 바를 '현재 레벨 마커'에서 '다음 레벨 마커' 사이만 채우도록 오프셋/폭 계산
+  const currentLevel = characterInfo?.level ?? memberInfo.level;
+  const segmentPercent = characterInfo?.expPercent ?? expPercent; // 0~100 (현재 레벨 구간 진행도)
+  const leftOffsetPercent = currentLevel === 2 ? 50 : 0; // 1레벨 구간: 0%, 2레벨 구간: 50%, 3레벨은 전체 채움
+  const widthPercent = currentLevel === 3 ? 100 : Math.max(0, Math.min(100, segmentPercent)) * 0.5; // 각 구간은 전체 바의 50%
+  const displayPercent = currentLevel === 3 ? 100 : Math.round(Math.max(0, Math.min(100, segmentPercent)) * 0.5);
+  const nextLevelLabel = currentLevel >= 3 ? '최고 레벨' : '다음 레벨까지';
 
   return (
       <div className="min-h-screen bg-gradient-to-b from-[#f7fafd] to-[#e6eaf3] flex flex-col items-center justify-center py-16 relative overflow-hidden">
@@ -387,26 +394,27 @@ export default function MyPage() {
                   </span>
                   </div>
                   <div className="relative w-full h-8 bg-white/60 rounded-full overflow-hidden shadow-inner mb-6 border-2 border-[#e0e7ef]">
+                    {/* 구간 진행도: 1레벨(0~50%), 2레벨(50~100%), 3레벨은 전체 채움 */}
                     <div
-                        className="absolute left-0 top-0 h-8 bg-gradient-to-r from-[#7f9cf5] via-[#43e6b5] to-[#bfe0f5] rounded-full transition-all duration-1000 ease-out border border-white/50"
-                        style={{ width: `${Math.max(characterInfo?.expPercent || 0, 5)}%` }}
+                        className="absolute top-0 h-8 bg-gradient-to-r from-[#7f9cf5] via-[#43e6b5] to-[#bfe0f5] rounded-full transition-all duration-700 ease-out border border-white/50"
+                        style={{ left: `${leftOffsetPercent}%`, width: `${widthPercent}%` }}
                     />
                     {/* 경험치 바 내부 반짝이는 효과 */}
                     <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent animate-pulse"></div>
                     {/* 경험치 텍스트 */}
                     <div className="absolute inset-0 flex items-center justify-center text-xs text-[#2b6cb0] font-bold">
-                      {characterInfo?.expPercent || 0}% (EXP: {characterInfo?.exp || 0}, Level: {characterInfo?.level || 1})
+                      {currentLevel >= 3 ? '최고 레벨 달성' : `${nextLevelLabel} ${displayPercent}% 진행`}
                     </div>
                   </div>
 
                   <div className="grid grid-cols-2 gap-6">
                     <div className="text-center p-4 bg-gradient-to-r from-[#f8fafc] to-[#e6f1fb] rounded-2xl border border-[#e0e7ef]/50">
-                      <div className="text-sm text-[#64748b] font-medium mb-1">현재 경험치</div>
-                      <div className="text-2xl text-[#2b6cb0] font-bold">{characterInfo?.exp || 0}</div>
+                      <div className="text-sm text-[#64748b] font-medium mb-1">현재 레벨</div>
+                      <div className="text-2xl text-[#2b6cb0] font-bold">{(characterInfo?.level || 1)}레벨</div>
                     </div>
                     <div className="text-center p-4 bg-gradient-to-r from-[#f8fafc] to-[#e6f1fb] rounded-2xl border border-[#e0e7ef]/50">
-                      <div className="text-sm text-[#64748b] font-medium mb-1">현재 레벨</div>
-                      <div className="text-2xl text-[#2b6cb0] font-bold">{characterInfo?.level || 1}</div>
+                      <div className="text-sm text-[#64748b] font-medium mb-1">현재 경험치</div>
+                      <div className="text-2xl text-[#2b6cb0] font-bold">{(characterInfo?.exp || 0)}점</div>
                     </div>
                   </div>
                 </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -215,9 +215,13 @@ export default function MyPage() {
   // 전체 바를 200%로 보고 (1레벨 0~100, 2레벨 100~200), 시각적 바는 0~100%로 환산
   const cappedExp = Math.max(0, Math.min(characterInfo?.exp ?? memberInfo.exp, 200));
   const widthPercent = Math.round((cappedExp / 200) * 100); // 0~100
-  // 텍스트는 이전처럼 '다음 레벨까지' 진행률로 안내
-  const segmentPercent = characterInfo?.expPercent ?? expPercent; // 0~100 (현재 레벨 구간 진행도)
-  const displayPercent = currentLevel >= 3 ? 100 : Math.round(Math.max(0, Math.min(100, segmentPercent)) * 0.5);
+  // 텍스트: 현재 레벨 구간 진행도 (1레벨: 0~100, 2레벨: 100~200를 0~100으로 환산)
+  const absoluteExp = characterInfo?.exp ?? memberInfo.exp;
+  const textPercent = currentLevel >= 3
+    ? 100
+    : currentLevel === 2
+      ? Math.max(0, Math.min(100, Math.round(((absoluteExp - 100) / 100) * 100)))
+      : Math.max(0, Math.min(100, Math.round((absoluteExp / 100) * 100)));
   const nextLevelLabel = currentLevel >= 3 ? '최고 레벨' : '다음 레벨까지';
 
   return (
@@ -405,7 +409,7 @@ export default function MyPage() {
                     <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent animate-pulse"></div>
                     {/* 경험치 텍스트 */}
                     <div className="absolute inset-0 flex items-center justify-center text-xs text-[#2b6cb0] font-bold">
-                      {currentLevel >= 3 ? '최고 레벨 달성' : `${nextLevelLabel} ${displayPercent}% 진행`}
+                      {currentLevel >= 3 ? '최고 레벨 달성' : `${nextLevelLabel} ${textPercent}% 진행`}
                     </div>
                   </div>
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -212,10 +212,12 @@ export default function MyPage() {
   const expPercent = calculateExpPercent(memberInfo.exp, memberInfo.level);
   // 바를 '현재 레벨 마커'에서 '다음 레벨 마커' 사이만 채우도록 오프셋/폭 계산
   const currentLevel = characterInfo?.level ?? memberInfo.level;
+  // 전체 바를 200%로 보고 (1레벨 0~100, 2레벨 100~200), 시각적 바는 0~100%로 환산
+  const cappedExp = Math.max(0, Math.min(characterInfo?.exp ?? memberInfo.exp, 200));
+  const widthPercent = Math.round((cappedExp / 200) * 100); // 0~100
+  // 텍스트는 이전처럼 '다음 레벨까지' 진행률로 안내
   const segmentPercent = characterInfo?.expPercent ?? expPercent; // 0~100 (현재 레벨 구간 진행도)
-  const leftOffsetPercent = currentLevel === 2 ? 50 : 0; // 1레벨 구간: 0%, 2레벨 구간: 50%, 3레벨은 전체 채움
-  const widthPercent = currentLevel === 3 ? 100 : Math.max(0, Math.min(100, segmentPercent)) * 0.5; // 각 구간은 전체 바의 50%
-  const displayPercent = currentLevel === 3 ? 100 : Math.round(Math.max(0, Math.min(100, segmentPercent)) * 0.5);
+  const displayPercent = currentLevel >= 3 ? 100 : Math.round(Math.max(0, Math.min(100, segmentPercent)) * 0.5);
   const nextLevelLabel = currentLevel >= 3 ? '최고 레벨' : '다음 레벨까지';
 
   return (
@@ -394,10 +396,10 @@ export default function MyPage() {
                   </span>
                   </div>
                   <div className="relative w-full h-8 bg-white/60 rounded-full overflow-hidden shadow-inner mb-6 border-2 border-[#e0e7ef]">
-                    {/* 구간 진행도: 1레벨(0~50%), 2레벨(50~100%), 3레벨은 전체 채움 */}
+                    {/* 전체 누적 진행도: 0~200%를 0~100%로 환산하여 표시 (1레벨 절반, 2레벨까지 전부) */}
                     <div
-                        className="absolute top-0 h-8 bg-gradient-to-r from-[#7f9cf5] via-[#43e6b5] to-[#bfe0f5] rounded-full transition-all duration-700 ease-out border border-white/50"
-                        style={{ left: `${leftOffsetPercent}%`, width: `${widthPercent}%` }}
+                        className="absolute left-0 top-0 h-8 bg-gradient-to-r from-[#7f9cf5] via-[#43e6b5] to-[#bfe0f5] rounded-full transition-all duration-700 ease-out border border-white/50"
+                        style={{ width: `${widthPercent}%` }}
                     />
                     {/* 경험치 바 내부 반짝이는 효과 */}
                     <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent animate-pulse"></div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 마이페이지 경험치 표시가 레벨별 진행도를 정확히 반영하도록 개선되었습니다. 레벨 1·2는 해당 레벨 내 0–100%로 계산되며, 레벨 3은 100%로 고정됩니다.
  * 경험치 오버레이 텍스트가 다음 레벨 라벨과 레벨 기준 퍼센트를 함께 표시합니다.
  * 진행 바의 전체 너비(누적 EXP 0–200 기준)는 기존과 동일해 레이아웃 변화가 없습니다.
  * 표시 값은 정상 범위로 클램핑되어 비정상 수치가 노출되지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->