### PR TITLE
[fix] 로그인 리다이렉트 페이지

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useAuth } from '@/contexts/AuthContext';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 export default function LoginPage() {
 
@@ -11,6 +11,8 @@ export default function LoginPage() {
   const frontendUrl = process.env.NEXT_PUBLIC_FRONTEND_URL || 'http://localhost:3000';
 
   const router = useRouter();
+  const searchParams = useSearchParams(); 
+  const redirectUrl = searchParams.get('redirect') || '/'; 
   const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -44,17 +46,17 @@ export default function LoginPage() {
 
       if (response.ok) {
         const data = await response.json();
-        
+
         console.log('로그인 응답 데이터:', data);
         
         // 로그인 성공 시 사용자 정보를 AuthContext에 저장
         if (data.data) {
           console.log('AuthContext에 저장할 사용자 데이터:', data.data);
           login(data.data);
-          router.push('/');
+          router.push(redirectUrl);
         } else {
           console.log('사용자 데이터가 없음');
-          router.push('/');
+          router.push(redirectUrl);
         }
       } else {
         const data = await response.json();
@@ -129,7 +131,7 @@ export default function LoginPage() {
         
         {/* 네이버 소셜로그인 */}
         <a 
-          href={`/api/oauth2/authorization/naver?redirectUrl=${encodeURIComponent(typeof window !== 'undefined' ? window.location.origin + '/' : frontendUrl + '/')}`}
+          href={`/api/oauth2/authorization/naver?redirectUrl=${encodeURIComponent(typeof window !== 'undefined' ? window.location.origin + redirectUrl : frontendUrl + redirectUrl)}`}
           className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#03C75A] text-white hover:opacity-90 transition mb-1"
         >
           <Image src="/social/naver_login.png" alt="네이버 로고" width={24} height={24} className="group-hover:opacity-80 transition" />
@@ -138,7 +140,7 @@ export default function LoginPage() {
 
         {/* 구글 소셜로그인 */}
         <a 
-          href={`/api/oauth2/authorization/google?redirectUrl=${encodeURIComponent(typeof window !== 'undefined' ? window.location.origin + '/' : frontendUrl + '/')}`}
+          href={`/api/oauth2/authorization/google?redirectUrl=${encodeURIComponent(typeof window !== 'undefined' ? window.location.origin + redirectUrl : frontendUrl + redirectUrl)}`}
           className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FFFFFF] border border-gray-300 text-[#3c4043] hover:bg-gray-50 transition mb-1"
         >
           <Image src="/social/google_login.png" alt="구글 로고" width={24} height={24} className="ml-[-13px] group-hover:opacity-80 transition" />
@@ -147,7 +149,7 @@ export default function LoginPage() {
 
         {/* 카카오 소셜로그인 */}
         <a 
-          href={`/api/oauth2/authorization/kakao?redirectUrl=${encodeURIComponent(typeof window !== 'undefined' ? window.location.origin + '/' : frontendUrl + '/')}`}
+          href={`/api/oauth2/authorization/kakao?redirectUrl=${encodeURIComponent(typeof window !== 'undefined' ? window.location.origin + redirectUrl : frontendUrl + redirectUrl)}`}
           className="group w-full flex items-center gap-3 justify-center h-10 text-base font-medium rounded-full shadow bg-[#FEE500] text-[#3C1E1E] hover:bg-[#FFEB3B] transition mb-1"
         >
           <Image src="/social/kakao_login.png" alt="카카오 로고" width={24} height={24} className="group-hover:opacity-70 transition" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 로그인 후 이동할 경로를 URL의 redirect 파라미터로 지정할 수 있습니다(기본값 ‘/’).  
  * 표준 로그인과 소셜 로그인(네이버/구글/카카오) 모두 지정한 redirect 경로를 일관되게 적용합니다.  
  * 브라우저/비브라우저 환경에서 모두 올바른 리다이렉트 주소가 생성되도록 처리했습니다.  
  * 로그인 성공 시는 물론, 데이터가 없거나 실패한 경우에도 설정된 경로로 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->